### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/rsync.js
+++ b/rsync.js
@@ -499,11 +499,11 @@ Rsync.prototype.execute = function(callback, stdoutHandler, stderrHandler) {
     // see https://github.com/joyent/node/blob/937e2e351b2450cf1e9c4d8b3e1a4e2a2def58bb/lib/child_process.js#L589
     var cmdProc;
     if ('win32' === process.platform) {
-        cmdProc = spawn('cmd.exe', ['/s', '/c', '"' + this.command() + '"'],
+        cmdProc = spawn(this.executable(), this.args(),
                         { stdio: 'pipe', windowsVerbatimArguments: true, cwd: this._cwd, env: this._env });
     }
     else {
-        cmdProc = spawn(this._executableShell, ['-c', this.command()],
+        cmdProc = spawn(this.executable(), this.args(),
                         { stdio: 'pipe', cwd: this._cwd, env: this._env });
     }
 


### PR DESCRIPTION
### ⚙️ Description *

I've changed how the module calls `rsync` to prevent a command injection vulnerability.

### 💻 Technical Description *

Instead of having this module call cmd.exe or /bin/sh on execution, I've changed it so that it calls `rsync` directly and passes the arguments as an array to `spawn`, which remediates the command injection vulnerability.

### 🐛 Proof of Concept (PoC) *

When running this snippet on the original module, this will produce a file named HACKED, proving that this module has a command injection vulnerability:
```js
const Rsync = require('./rsync')
new Rsync().flags("a;touch HACKED;").execute()
```


### 🔥 Proof of Fix (PoF) *

When the above snippet is ran in my fork of the module, nothing happens as it's properly escaped.

### 👍 User Acceptance Testing (UAT)

Running `yarn run test` tests the functionality of the module, and after my modifications, the application still passes [all 96 tests](https://gist.github.com/69/72006d2d7be1f07236c2284890080f1d).